### PR TITLE
Added missing and necessary semicolon

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -153,5 +153,5 @@ module.exports = function (grunt) {
     'clean',
     'coffee',
     'coverageBackend'
-  ])
+  ]);
 };


### PR DESCRIPTION
Gruntfile would not compile without the missing semicolon due to jshint failure. I added the semicolon to fix this.
