### PR TITLE
update yo dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "mocha": "~1.12.0"
   },
   "peerDependencies": {
-    "yo": "~1.0.3"
+    "yo": ">= 1.0.3"
   },
   "engines": {
     "node": ">= 0.8.0",


### PR DESCRIPTION
Attempting to install where other generators are already installed, and yo 1.1.2 is installed was giving the following error:

```
npm ERR! peerinvalid The package yo does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer generator-coffee-module@0.5.2 wants yo@>=1.0.0
npm ERR! peerinvalid Peer generator-gruntfile@0.0.9 wants yo@>=1.0.0
npm ERR! peerinvalid Peer generator-node@0.0.8 wants yo@>=1.0.3
npm ERR! peerinvalid Peer generator-node-coffee@0.0.3 wants yo@~1.0.3
```
